### PR TITLE
Fix "DMFI Modif Septirage" for DM  sentences

### DIFF
--- a/sources/js/global.js
+++ b/sources/js/global.js
@@ -1013,7 +1013,7 @@ const processLog = (thisLog, filename, resultByLine) => {
 
             let prevLineMatch = prevSearch.exec(prevLine)
 
-            pseudo = prevLineMatch[2].trim()
+            pseudo = prevLineMatch[2] === undefined ? '(pnj ou dm)' : prevLineMatch[2].trim()
             pjName = prevLineMatch[3].trim().slice(0, -1)
             msgType = prevLineMatch[4]
 


### PR DESCRIPTION
Make sure we have a defined 'pseudo' before trim it in this case too.